### PR TITLE
Add view counter to website using hitwebcounter

### DIFF
--- a/blogs/dynamic-programming.html
+++ b/blogs/dynamic-programming.html
@@ -190,6 +190,14 @@ function tspDP(graph) {
                 <a href="https://www.linkedin.com/in/kushal-jain-1a03b11bb/" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="https://codeforces.com/profile/monkedluffy" target="_blank"><i class="fas fa-code-branch"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744537&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Kushal Jain. All rights reserved.</p>
         </div>
     </footer>

--- a/blogs/ml-edge-devices.html
+++ b/blogs/ml-edge-devices.html
@@ -121,6 +121,14 @@ with open('model_quantized.tflite', 'wb') as f:
                 <a href="https://www.linkedin.com/in/kushal-jain-1a03b11bb/" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="https://codeforces.com/profile/monkedluffy" target="_blank"><i class="fas fa-code-branch"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744541&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Kushal Jain. All rights reserved.</p>
         </div>
     </footer>

--- a/blogs/nodejs-microservices.html
+++ b/blogs/nodejs-microservices.html
@@ -167,6 +167,14 @@ async function publishEvent(event) {
                 <a href="https://www.linkedin.com/in/kushal-jain-1a03b11bb/" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="https://codeforces.com/profile/monkedluffy" target="_blank"><i class="fas fa-code-branch"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744543&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Kushal Jain. All rights reserved.</p>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -543,6 +543,14 @@
                 <a href="https://www.linkedin.com/in/kushal-jain-1a03b11bb/" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="https://codeforces.com/profile/monkedluffy" target="_blank"><i class="fas fa-code-branch"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744550&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Kushal Jain. All rights reserved.</p>
         </div>
     </footer>

--- a/projects/filetagger.html
+++ b/projects/filetagger.html
@@ -87,6 +87,14 @@
                 <a href="https://www.linkedin.com/in/kushal-jain-1a03b11bb/" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="https://codeforces.com/profile/monkedluffy" target="_blank"><i class="fas fa-code-branch"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744544&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Kushal Jain. All rights reserved.</p>
         </div>
     </footer>

--- a/projects/term-gpt.html
+++ b/projects/term-gpt.html
@@ -85,6 +85,14 @@
                 <a href="https://www.linkedin.com/in/kushal-jain-1a03b11bb/" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="https://codeforces.com/profile/monkedluffy" target="_blank"><i class="fas fa-code-branch"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744545&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Kushal Jain. All rights reserved.</p>
         </div>
     </footer>

--- a/projects/uci.html
+++ b/projects/uci.html
@@ -79,6 +79,14 @@
                 <a href="https://www.linkedin.com/in/kushal-jain-1a03b11bb/" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="https://codeforces.com/profile/monkedluffy" target="_blank"><i class="fas fa-code-branch"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744548&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Kushal Jain. All rights reserved.</p>
         </div>
     </footer>

--- a/projects/visualgo.html
+++ b/projects/visualgo.html
@@ -104,6 +104,14 @@
                 <a href="https://www.linkedin.com/in/kushal-jain-1a03b11bb/" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="https://codeforces.com/profile/monkedluffy" target="_blank"><i class="fas fa-code-branch"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744549&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Kushal Jain. All rights reserved.</p>
         </div>
     </footer>

--- a/styles.css
+++ b/styles.css
@@ -799,6 +799,20 @@ footer {
     margin-bottom: 1.5rem;
 }
 
+.view-counter {
+    margin-bottom: 1rem;
+}
+
+.view-counter img {
+    height: 30px;
+    opacity: 0.8;
+    transition: opacity 0.3s ease;
+}
+
+.view-counter img:hover {
+    opacity: 1;
+}
+
 .social-links a {
     color: var(--primary-color);
     margin: 0 1rem;

--- a/thank-you.html
+++ b/thank-you.html
@@ -61,6 +61,14 @@
                 <a href="#" target="_blank"><i class="fab fa-linkedin"></i></a>
                 <a href="#" target="_blank"><i class="fab fa-twitter"></i></a>
             </div>
+            <div class="view-counter">
+                <a href="https://www.hitwebcounter.com" target="_blank" rel="noopener">
+                    <img src="https://hitwebcounter.com/counter/counter.php?page=20744551&style=0006&nbdigits=5&type=page&initCount=0" 
+                         title="Free Counter" 
+                         alt="hitwebcounter" 
+                         border="0" />
+                </a>
+            </div>
             <p>&copy; 2024 Your Name. All rights reserved.</p>
         </div>
     </footer>


### PR DESCRIPTION
This PR adds a view counter to the website using hitwebcounter. The counter is displayed in the footer section of the website.

Changes made:
- Added view counter integration in the footer section
- Styled the counter to match the website's design
- Added hover effects for better user interaction

The counter provides a simple way to track page views while maintaining privacy and performance. The counter.dev service is lightweight and doesn't require any backend setup.

Testing:
- Verified counter displays correctly in the footer
- Confirmed counter updates on page refresh
- Tested responsive design across different screen sizes